### PR TITLE
Update `nanorand` to 0.5.1, fixing potentially dangerous RNG weakness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "nanorand"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee0409eacc25d781c09d1853b5a40ae3ad1e641752bff319b0382f6dcba6772a"
+checksum = "3173d7bb904c5a3a2f9167eb936916a39e97124846b8316223323aed9a34d1e7"
 
 [[package]]
 name = "passphrase_lib"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ license = "Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-nanorand = { version = "0.5.0", features = ["chacha"] }
+nanorand = { version = "^0.5.1", features = ["chacha"] }
 


### PR DESCRIPTION
RNGs in nanorand 0.5.0 did _not_ work properly for non-64 bit numbers, due to a failure to truncate.